### PR TITLE
TypeError: tarteaucitron.user.multiplegtagUa

### DIFF
--- a/tarteaucitron.services.js
+++ b/tarteaucitron.services.js
@@ -2816,14 +2816,15 @@ tarteaucitron.services.multiplegtag = {
         "use strict";
         window.dataLayer = window.dataLayer || [];
 
-        tarteaucitron.user.multiplegtagUa.forEach(function(ua) {
-
-            tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + ua, '', function () {
-                window.gtag = function gtag(){dataLayer.push(arguments);}
-                gtag('js', new Date());
-                gtag('config', ua);
+	if (tarteaucitron.user.multiplegtagUa !== undefined) {
+            tarteaucitron.user.multiplegtagUa.forEach(function(ua) {
+                tarteaucitron.addScript('https://www.googletagmanager.com/gtag/js?id=' + ua, '', function () {
+                    window.gtag = function gtag(){dataLayer.push(arguments);}
+                    gtag('js', new Date());
+                    gtag('config', ua);
+                });
             });
-        });
+	}
     }
 };
 


### PR DESCRIPTION
A simple patch to avoid "Uncaught TypeError: tarteaucitron.user.multiplegtagUa" like reported in #474.